### PR TITLE
Add hash algorithm to tc26_gost_3410_12_256 key generation 

### DIFF
--- a/gost_ameth.c
+++ b/gost_ameth.c
@@ -75,6 +75,10 @@ static ASN1_STRING *encode_gost_algor_params(const EVP_PKEY *key)
 	    case NID_id_GostR3410_2001_CryptoPro_C_ParamSet:
 	    case NID_id_GostR3410_2001_CryptoPro_XchA_ParamSet:
 	    case NID_id_GostR3410_2001_CryptoPro_XchB_ParamSet:
+  	    case NID_id_tc26_gost_3410_2012_256_paramSetA:
+	    case NID_id_tc26_gost_3410_2012_256_paramSetB:
+	    case NID_id_tc26_gost_3410_2012_256_paramSetC:
+	    case NID_id_tc26_gost_3410_2012_256_paramSetD:
 		gkp->hash_params = OBJ_nid2obj(NID_id_GostR3411_2012_256);
 	}
         break;


### PR DESCRIPTION
В https://github.com/gost-engine/engine/issues/84 внедрили TCA ... TCD параметры для ECGOST3410-2012-256, но в отличие от других параметров, создание приватного и публичногго ключей не приводит к добавлению записи GOST R 34.11-2012 with 256 bit hash, что привоодит к тому, что приватный ключ не читается в Bouncy Castle библиотеке. Видимо, при внедрении новых параметров забыли добавить в перечисление новые параметры.

Было:
```
$ openssl asn1parse -in key256a.pem
    0:d=0  hl=2 l=  62 cons: SEQUENCE
    2:d=1  hl=2 l=   1 prim: INTEGER           :00
    5:d=1  hl=2 l=  23 cons: SEQUENCE
    7:d=2  hl=2 l=   8 prim: OBJECT            :GOST R 34.10-2012 with 256 bit modulus
   17:d=2  hl=2 l=  11 cons: SEQUENCE
   19:d=3  hl=2 l=   9 prim: OBJECT            :GOST R 34.10-2012 (256 bit) ParamSet A
   30:d=1  hl=2 l=  32 prim: OCTET STRING      [HEX DUMP]:...
 ```

Стало:
```
$ openssl asn1parse -in key256tca.pem
    0:d=0  hl=2 l=  72 cons: SEQUENCE
    2:d=1  hl=2 l=   1 prim: INTEGER           :00
    5:d=1  hl=2 l=  33 cons: SEQUENCE
    7:d=2  hl=2 l=   8 prim: OBJECT            :GOST R 34.10-2012 with 256 bit modulus
   17:d=2  hl=2 l=  21 cons: SEQUENCE
   19:d=3  hl=2 l=   9 prim: OBJECT            :GOST R 34.10-2012 (256 bit) ParamSet A
   30:d=3  hl=2 l=   8 prim: OBJECT            :GOST R 34.11-2012 with 256 bit hash
   40:d=1  hl=2 l=  32 prim: OCTET STRING      [HEX DUMP]:...
 ```